### PR TITLE
ED-265/crypto-currency condition

### DIFF
--- a/apps/party_management/src/pm_party.erl
+++ b/apps/party_management/src/pm_party.erl
@@ -272,6 +272,7 @@ is_terms({struct, struct, {dmsl_domain_thrift, Struct}}, Terms) when
     Struct =:= 'PaymentRefundsServiceTerms';
     Struct =:= 'PartialRefundsServiceTerms';
     Struct =:= 'PaymentChargebackServiceTerms';
+    Struct =:= 'PartialCaptureServiceTerms';
     Struct =:= 'PayoutsServiceTerms';
     Struct =:= 'ReportsServiceTerms';
     Struct =:= 'ServiceAcceptanceActsTerms';

--- a/apps/party_management/src/pm_payment_tool.erl
+++ b/apps/party_management/src/pm_payment_tool.erl
@@ -260,7 +260,7 @@ test_crypto_currency_condition_def({crypto_currency_is, C1}, {ref, C2}, _Rev) ->
 test_crypto_currency_condition_def({crypto_currency_is_deprecated, C1}, {legacy, C2}, _Rev) ->
     C1 =:= C2;
 test_crypto_currency_condition_def(_Cond, _Data, _Rev) ->
-    undefined.
+    false.
 
 test_mobile_commerce_condition(#domain_MobileCommerceCondition{definition = Def}, V, Rev) ->
     Def =:= undefined orelse test_mobile_commerce_condition_def(Def, V, Rev).

--- a/apps/party_management/src/pm_payment_tool.erl
+++ b/apps/party_management/src/pm_payment_tool.erl
@@ -234,7 +234,9 @@ test_payment_terminal_condition_def(
     #domain_PaymentTerminal{terminal_type_deprecated = V2},
     _Rev
 ) ->
-    V1 =:= V2.
+    V1 =:= V2;
+test_payment_terminal_condition_def(_Cond, _Data, _Rev) ->
+    false.
 
 test_digital_wallet_condition(#domain_DigitalWalletCondition{definition = Def}, V, Rev) ->
     Def =:= undefined orelse test_digital_wallet_condition_def(Def, V, Rev).
@@ -250,7 +252,9 @@ test_digital_wallet_condition_def(
     #domain_DigitalWallet{provider_deprecated = V2},
     _Rev
 ) ->
-    V1 =:= V2.
+    V1 =:= V2;
+test_digital_wallet_condition_def(_Cond, _Data, _Rev) ->
+    false.
 
 test_crypto_currency_condition(#domain_CryptoCurrencyCondition{definition = Def}, V, Rev) ->
     Def =:= undefined orelse test_crypto_currency_condition_def(Def, V, Rev).
@@ -276,4 +280,6 @@ test_mobile_commerce_condition_def(
     #domain_MobileCommerce{operator_deprecated = C2},
     _Rev
 ) ->
-    C1 =:= C2.
+    C1 =:= C2;
+test_mobile_commerce_condition_def(_Cond, _Data, _Rev) ->
+    false.


### PR DESCRIPTION
Пояснение изменения:
В коде сравниваются криптовалюты только с себе подобными (Вариант легаси и рефов отметается: ``undefined``)
```
test_crypto_currency_condition_def({crypto_currency_is, C1}, {ref, C2}, _Rev) ->
    C1 =:= C2;
test_crypto_currency_condition_def({crypto_currency_is_deprecated, C1}, {legacy, C2}, _Rev) ->
    C1 =:= C2;
test_crypto_currency_condition_def(_Cond, _Data, _Rev) ->
    undefined.
```
А в селекторе требуется результат сравнения:
```
reduce_condition(C, VS, Rev) ->
    case pm_condition:test(C, VS, Rev) of
        B when is_boolean(B) ->
            ?const(B);
        undefined ->
            % Irreducible, return as is for further possible reduce
            C
    end.
```
Иначе условие остаётся неизменным:
```
reduce_predicate({condition, C0}, VS, Rev) ->
    case reduce_condition(C0, VS, Rev) of
        ?const(B) ->
            ?const(B);
        C1 ->
            {condition, C1}
    end;
```
Что приводит к выбору первого селектора:
```
    case reduce_predicate(Predicate, VS, Rev) of
        ?const(false) ->
            reduce_decisions(Rest, VS, Rev);
        NewPredicate ->
            case reduce(Selector, VS, Rev) of
                {decisions, []} ->
                    reduce_decisions(Rest, VS, Rev);
                NewSelector ->
                    [{Type, NewPredicate, NewSelector} | reduce_decisions(Rest, VS, Rev)]
            end
    end;
```
вот тут:
```
reduce({decisions, Decisions}, VS, Rev) ->
    case reduce_decisions(Decisions, VS, Rev) of
        %% Return value only if topmost decision's predicate resolved to true:
        %% otherwise,
        %% the decision was either dropped (predicate reduced to false)
        %% or there's not enough info to reduce a predicate (the result is undefined)
        [{_Type, ?const(true), Selector} | _] ->
            Selector;
        Ps1 ->
            {decisions, Ps1}
    end.
```