### PR TITLE
ED-293/ComputeContractTerms for firstful-server

### DIFF
--- a/apps/party_management/src/pm_party_handler.erl
+++ b/apps/party_management/src/pm_party_handler.erl
@@ -66,9 +66,14 @@ handle_function_('ComputeContractTerms', Args, _Opts) ->
                 };
             #{wallet_id := WalletID} = VS0 ->
                 Wallet = pm_party:get_wallet(WalletID, Party),
-                VS0#{
-                    currency => (Wallet#domain_Wallet.account)#domain_WalletAccount.currency
-                };
+                case Wallet of
+                    undefined ->
+                        VS0;
+                    Wallet ->
+                        VS0#{
+                            currency => (Wallet#domain_Wallet.account)#domain_WalletAccount.currency
+                        }
+                end;
             #{} = VS0 ->
                 VS0
         end,

--- a/apps/party_management/src/pm_party_handler.erl
+++ b/apps/party_management/src/pm_party_handler.erl
@@ -64,6 +64,11 @@ handle_function_('ComputeContractTerms', Args, _Opts) ->
                     category => Shop#domain_Shop.category,
                     currency => (Shop#domain_Shop.account)#domain_ShopAccount.currency
                 };
+            #{wallet_id := WalletID} = VS0 ->
+                Wallet = pm_party:get_wallet(WalletID, Party),
+                VS0#{
+                    currency => (Wallet#domain_Wallet.account)#domain_WalletAccount.currency
+                };
             #{} = VS0 ->
                 VS0
         end,

--- a/apps/party_management/src/pm_party_handler.erl
+++ b/apps/party_management/src/pm_party_handler.erl
@@ -60,20 +60,11 @@ handle_function_('ComputeContractTerms', Args, _Opts) ->
         case pm_varset:decode_varset(Varset) of
             #{shop_id := ShopID} = VS0 ->
                 Shop = ensure_shop(pm_party:get_shop(ShopID, Party)),
+                Currency = maps:get(currency, VS0, (Shop#domain_Shop.account)#domain_ShopAccount.currency),
                 VS0#{
                     category => Shop#domain_Shop.category,
-                    currency => (Shop#domain_Shop.account)#domain_ShopAccount.currency
+                    currency => Currency
                 };
-            #{wallet_id := WalletID} = VS0 ->
-                Wallet = pm_party:get_wallet(WalletID, Party),
-                case Wallet of
-                    undefined ->
-                        VS0;
-                    Wallet ->
-                        VS0#{
-                            currency => (Wallet#domain_Wallet.account)#domain_WalletAccount.currency
-                        }
-                end;
             #{} = VS0 ->
                 VS0
         end,


### PR DESCRIPTION
В кратце о проблеме:

В рамках задаче [[ED-293](https://rbkmoney.atlassian.net/browse/ED-293)] об оптимизации протокола для вызова методов сервиса _PartyManagement_ (ComputeShopTerms, ComputeContractTerms) из _Varset_ были убрано в том числе поле _currency_. Для _Hellgate_ данные поля восстанавливаются по _ShopID_. В этом PR делается попытка восстановить то же поле для _Fistful-server_ по _WalletID_.

З.Ы.: При локальном тестировании выявилось следующее: массив _wallets_ из domain_Party не всегда содержит записи по передаваемым идентификаторам кошельков. Например, при создании какого-то аккаунта _ff_account:create/3_. Не понятно это аккаунт чего? Почему кошелёк не создаётся с помощью _CreateClaim_?